### PR TITLE
3.6 Branch | Include project version in resulting Application Bundle

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
     "app_name": "appname",
+    "version": "1.0.0",
     "formal_name": "App Name",
     "dir_name": "macOS",
     "bundle": "com.example",

--- a/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
+++ b/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}.app/Contents/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>{{ cookiecutter.version }}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Hello BeeWare! :)

The subject says it all, I suppose.

While reviewing [Mu Editor](https://github.com/mu-editor/mu/)'s macOS packaging I stumbled upon the fact that the Application Bundle produced by [briefcase](https://pypi.org/project/briefcase/) includes a hard-coded "1.0" version -- I logged that fact [here](https://github.com/mu-editor/mu/issues/925).

After a bit of digging I found out that the culprit was this template which I've hand changed on my dev system, much like in this PR, confirming it works as expected.

I'd love your review towards having this changed merged in, if it fits the general requirements of BeeWare. In that case, I will also happily submit equivalent PRs for the remaining branches.

Thanks in advace! :)